### PR TITLE
Skip enforcer checks for the parent

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,17 +18,8 @@ primogenitor
 To build this project, you must use:
 
 ```
-$ mvn -Denforcer.skip=true clean package
+$ mvn clean package
 ```
-
-The reason for this is that this POM file is intended to be the
-root POM for [io7m](http://io7m.com) projects and uses the [Maven
-Enforcer](https://maven.apache.org/enforcer/maven-enforcer-plugin/)
-plugin to require that descendant projects define values for certain
-properties that this root POM leaves empty. Because there is no way
-in Maven to have a plugin applied only to descendants, the root POM
-actually cannot pass its own checks! Using the `enforcer.skip` property
-allows the root POM to be installed and deployed to repositories.
 
 ## Features
 

--- a/pom.xml
+++ b/pom.xml
@@ -937,6 +937,14 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
+        <inherited>false</inherited>
+          <!-- Skip checks for parent -->
+          <executions>
+            <execution>
+              <id>enforce-rules</id>
+              <phase>none</phase>
+            </execution>
+          </executions>
       </plugin>
 
       <plugin>


### PR DESCRIPTION
Set the phase of the enforcer-rules execution to none on the parent pom only.